### PR TITLE
Renaming driver/class to match product/repo name.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ install:
 - pip install pylint circuitpython-build-tools Sphinx sphinx-rtd-theme
 - pip install --force-reinstall pylint==1.9.2
 script:
-- pylint adafruit_sht31.py
+- pylint adafruit_sht31d.py
 - ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace
   examples/*.py)
-- circuitpython-build-bundles --filename_prefix adafruit-circuitpython-sht31 --library_location
+- circuitpython-build-bundles --filename_prefix adafruit-circuitpython-sht31d --library_location
   .
 - cd docs && sphinx-build -E -W -b html . _build/html && cd ..

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ You must import the library to use it:
 
 .. code:: python
 
-    import adafruit_sht31
+    import adafruit_sht31d
 
 This driver takes an instantiated and active I2C object (from the `busio` or
 the `bitbangio` library) as an argument to its constructor.  The way to create
@@ -53,7 +53,7 @@ the sensor object:
 
 .. code:: python
 
-    sensor = adafruit_sht31.SHT31(i2c)
+    sensor = adafruit_sht31d.SHT31D(i2c)
 
 
 And then you can start measuring the temperature and humidity:
@@ -67,7 +67,7 @@ Contributing
 ============
 
 Contributions are welcome! Please read our `Code of Conduct
-<https://github.com/adafruit/Adafruit_CircuitPython_sht31/blob/master/CODE_OF_CONDUCT.md>`_
+<https://github.com/adafruit/Adafruit_CircuitPython_SHT31D/blob/master/CODE_OF_CONDUCT.md>`_
 before contributing to help this project stay welcoming.
 
 Building locally
@@ -92,7 +92,7 @@ Then run the build:
 
 .. code-block:: shell
 
-    circuitpython-build-bundles --filename_prefix adafruit-circuitpython-sht31 --library_location .
+    circuitpython-build-bundles --filename_prefix adafruit-circuitpython-sht31d --library_location .
 
 Sphinx documentation
 -----------------------

--- a/adafruit_sht31d.py
+++ b/adafruit_sht31d.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 """
-`adafruit_sht31`
+`adafruit_sht31d`
 ====================================================
 
 This is a CircuitPython driver for the SHT31-D temperature and humidity sensor.
@@ -50,11 +50,11 @@ except ImportError:
 
 import time
 
-from adafruit_bus_device.i2c_device import I2CDevice
 from micropython import const
+from adafruit_bus_device.i2c_device import I2CDevice
 
 __version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_sht31.git"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_SHT31D.git"
 
 
 SHT31_DEFAULT_ADDR = const(0x44)
@@ -84,7 +84,7 @@ def _crc(data):
     return crc
 
 
-class SHT31:
+class SHT31D:
     """
     A driver for the SHT31-D temperature and humidity sensor.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,5 +1,5 @@
 
 .. If you created a package, create one automodule per module in the package.
 
-.. automodule:: adafruit_sht31
+.. automodule:: adafruit_sht31d
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Adafruit sht31 Library'
+project = u'Adafruit SHT31D Library'
 copyright = u'2017 Jerry Needell'
 author = u'Jerry Needell'
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -3,6 +3,6 @@ Simple test
 
 Ensure your device works with this simple test.
 
-.. literalinclude:: ../examples/sht31_simpletest.py
-    :caption: examples/sht31_simpletest.py
+.. literalinclude:: ../examples/sht31d_simpletest.py
+    :caption: examples/sht31d_simpletest.py
     :linenos:

--- a/examples/sht31d_simpletest.py
+++ b/examples/sht31d_simpletest.py
@@ -1,11 +1,11 @@
 import time
 import board
 import busio
-import adafruit_sht31
+import adafruit_sht31d
 
 # Create library object using our Bus I2C port
 i2c = busio.I2C(board.SCL, board.SDA)
-sensor = adafruit_sht31.SHT31(i2c)
+sensor = adafruit_sht31d.SHT31D(i2c)
 
 loopcount = 0
 while True:

--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,5 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    py_modules=['adafruit_sht31'],
+    py_modules=['adafruit_sht31d'],
 )


### PR DESCRIPTION
This renames the driver and the class to match the product description and the repo name. References to the original name have been updated.

This will require the guide be updated. Once this is merged I will attend to that.