### PR TITLE
Fix docstring of temperature function.

### DIFF
--- a/adafruit_sht31d.py
+++ b/adafruit_sht31d.py
@@ -116,7 +116,7 @@ class SHT31D:
 
     @property
     def temperature(self):
-        """The measured relative humidity in percent."""
+        """The measured temperature in degrees celsius."""
         raw_temperature, _ = self._data()
         return -45 + (175 * (raw_temperature / 65535))
 


### PR DESCRIPTION
The docstring of the temperature function doesn't not accurately describe its behaviour. It should be updated to reflect what the function actually does.