### PR TITLE
CRC Mismatch fix

### DIFF
--- a/adafruit_sht31d.py
+++ b/adafruit_sht31d.py
@@ -115,7 +115,7 @@ def _crc(data):
         for _ in range(8):
             if crc & 0x80:
                 crc <<= 1
-                crc ^= 0x131
+                crc ^= 0x31 # 
             else:
                 crc <<= 1
     return crc & 0xFF

--- a/adafruit_sht31d.py
+++ b/adafruit_sht31d.py
@@ -115,7 +115,7 @@ def _crc(data):
         for _ in range(8):
             if crc & 0x80:
                 crc <<= 1
-                crc ^= 0x31 # 
+                crc ^= 0x31
             else:
                 crc <<= 1
     return crc & 0xFF

--- a/adafruit_sht31d.py
+++ b/adafruit_sht31d.py
@@ -118,7 +118,7 @@ def _crc(data):
                 crc ^= 0x131
             else:
                 crc <<= 1
-    return crc
+    return crc & 0xFF
 
 
 def _unpack(data):


### PR DESCRIPTION
This needs to be tested on hardware, but it should fix #26 

There are two changes: CRC's returned value is now anded with `0xFF` to ensure it's one byte only.

The second change is from the CRC Polynomial, which was `0x131` and is now `0x31`. The datasheet and other Sensirion sensors all use `0x31`, however if you go through the Sensirion download center to download sample c++ code, the sample code uses `0x131`. Given the Sensirion github is more likely to be up to date, and given they now use a [helper library](https://github.com/Sensirion/embedded-common/blob/master/i2c/sensirion_i2c.h) for the CRC which sets the polynomial to `0x31`I think `0x31` is the correct option.  

But because that's a large enough change, I need that to be tested to be sure it fixes #26 