### PR TITLE
Fix Periodic Mode Example

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -21,6 +21,6 @@ Periodic Mode
 
 Example in how to use the sensor in periodic mode
 
-.. literalinclude:: ../examples/sht31d_simpletest.py
-    :caption: examples/sht31d_simpletest.py
+.. literalinclude:: ../examples/sht31d_periodic_mode.py
+    :caption: examples/sht31d_periodic_mode.py
     :linenos:


### PR DESCRIPTION
The Periodic Mode section in the examples was incorrectly duplicating the Simple test.  I have updated the link and caption to the correct example file.